### PR TITLE
feat: Operation to make labels consecutive

### DIFF
--- a/src/pointtorch/operations/numpy/__init__.py
+++ b/src/pointtorch/operations/numpy/__init__.py
@@ -3,6 +3,7 @@ Point cloud processing operations for the use with `numpy arrays
 <https://numpy.org/doc/stable/reference/generated/numpy.array.html>`_.
 """
 
+from ._make_labels_consecutive import *
 from ._voxel_downsampling import *
 
 __all__ = [name for name in globals().keys() if not name.startswith("_")]

--- a/src/pointtorch/operations/numpy/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/numpy/_make_labels_consecutive.py
@@ -1,0 +1,26 @@
+""" Transformation of input labels into consecutive integer labels. """
+
+__all__ = ["make_labels_consecutive"]
+
+import numpy as np
+
+
+def make_labels_consecutive(labels: np.ndarray, start_id: int = 0) -> np.ndarray:
+    """
+    Transforms the input labels into consecutive integer labels starting from a given :code:`start_id`.
+
+    Args:
+        labels: An array of original labels.
+        start_id: The starting ID for the consecutive labels. Defaults to zero.
+
+    Returns:
+        np.ndarray: An array with the transformed consecutive labels.
+    """
+
+    unique_labels = np.unique(labels)
+    unique_labels = np.sort(unique_labels)
+    key = np.arange(0, len(unique_labels))
+    index = np.digitize(labels, unique_labels, right=True)
+    labels = key[index]
+    labels = labels + start_id
+    return labels

--- a/src/pointtorch/operations/torch/__init__.py
+++ b/src/pointtorch/operations/torch/__init__.py
@@ -5,6 +5,7 @@ Point cloud processing operations for the use with
 
 from ._pack_batch import *
 from ._knn_search import *
+from ._make_labels_consecutive import *
 from ._neighbor_search import *
 from ._ravel_index import *
 from ._voxel_downsampling import *

--- a/src/pointtorch/operations/torch/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/torch/_make_labels_consecutive.py
@@ -1,0 +1,26 @@
+""" Transformation of input labels into consecutive integer labels. """
+
+__all__ = ["make_labels_consecutive"]
+
+import torch
+
+
+def make_labels_consecutive(labels: torch.Tensor, start_id: int = 0) -> torch.Tensor:
+    """
+    Transforms the input labels into consecutive integer labels starting from a given :code:`start_id`.
+
+    Args:
+        labels: An array of original labels.
+        start_id: The starting ID for the consecutive labels. Defaults to zero.
+
+    Returns:
+        numpy.ndarray: An array with the transformed consecutive labels.
+    """
+
+    unique_labels = torch.unique(labels)
+    unique_labels = torch.sort(unique_labels)[0]
+    key = torch.arange(0, len(unique_labels), device=labels.device)
+    index = torch.bucketize(labels, unique_labels, right=False)
+    labels = key[index]
+    labels = labels + start_id
+    return labels

--- a/test/operations/numpy/test_make_labels_consecutive.py
+++ b/test/operations/numpy/test_make_labels_consecutive.py
@@ -1,0 +1,17 @@
+""" Tests for pointtorch.operations.numpy.make_labels_consecutive. """
+
+import numpy as np
+
+from pointtorch.operations.numpy import make_labels_consecutive
+
+
+class TestMakeLabelsConsecutive:  # pylint: disable=too-few-public-methods
+    """Tests for pointtorch.operations.numpy.make_labels_consecutive."""
+
+    def test_make_labels_consecutive(self):
+        labels = np.array([10, 20, 20, 10, 30])
+        start_id = 5
+        expected_output = np.array([5, 6, 6, 5, 7])
+        output = make_labels_consecutive(labels, start_id)
+
+        np.testing.assert_array_equal(output, expected_output)

--- a/test/operations/torch/test_make_labels_consecutive.py
+++ b/test/operations/torch/test_make_labels_consecutive.py
@@ -1,0 +1,19 @@
+""" Tests for pointtorch.operations.numpy.make_labels_consecutive. """
+
+import numpy as np
+import pytest
+import torch
+
+from pointtorch.operations.torch import make_labels_consecutive
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"])
+class TestMakeLabelsConsecutive:  # pylint: disable=too-few-public-methods
+    """Tests for pointtorch.operations.numpy.make_labels_consecutive."""
+
+    def test_make_labels_consecutive(self, device: str):
+        labels = torch.tensor([10, 20, 20, 10, 30], device=device)
+        start_id = 5
+        expected_output = torch.tensor([5, 6, 6, 5, 7], device=device)
+        output = make_labels_consecutive(labels, start_id)
+        np.testing.assert_array_equal(output.cpu().numpy(), expected_output.cpu().numpy())


### PR DESCRIPTION
This pull requests adds numpy and Pytorch operations to map a set of integer labels into a consecutive range.