### PR TITLE
refactor: make_labels_consecutive operation

### DIFF
--- a/src/pointtorch/operations/numpy/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/numpy/_make_labels_consecutive.py
@@ -4,16 +4,17 @@ __all__ = ["make_labels_consecutive"]
 
 from typing import Optional, Tuple, Union
 
-import numpy
+import numpy as np
+import numpy.typing as npt
 
 
 def make_labels_consecutive(
-    labels: numpy.ndarray,
+    labels: npt.NDArray[np.int64],
     start_id: int = 0,
     ignore_id: Optional[int] = None,
     inplace: bool = False,
     return_unique_labels: bool = False,
-) -> Union[numpy.ndarray, Tuple[numpy.ndarray, numpy.ndarray]]:
+) -> Union[npt.NDArray[np.int64], Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]]:
     """
     Transforms the input labels into consecutive integer labels starting from a given :code:`start_id`.
 
@@ -33,23 +34,22 @@ def make_labels_consecutive(
 
     if len(labels) == 0:
         if return_unique_labels:
-            return labels, numpy.empty_like(labels)
+            return labels, np.empty_like(labels)
         return labels
 
     if not inplace:
         labels = labels.copy()
 
-    labels_to_remap: Union[numpy.ndarray, numpy.ma.MaskedArray]
     if ignore_id is not None:
         mask = labels != ignore_id
         labels_to_remap = labels[mask]
     else:
         labels_to_remap = labels
 
-    unique_labels = numpy.unique(labels_to_remap)
-    unique_labels = numpy.sort(unique_labels)
-    key = numpy.arange(0, len(unique_labels))
-    index = numpy.digitize(labels_to_remap, unique_labels, right=True)
+    unique_labels = np.unique(labels_to_remap)
+    unique_labels = np.sort(unique_labels)
+    key = np.arange(0, len(unique_labels))
+    index = np.digitize(labels_to_remap, unique_labels, right=True)
     labels_to_remap[:] = key[index]
     labels_to_remap += start_id
 

--- a/src/pointtorch/operations/numpy/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/numpy/_make_labels_consecutive.py
@@ -2,26 +2,63 @@
 
 __all__ = ["make_labels_consecutive"]
 
-import numpy as np
-import numpy.typing as npt
+from typing import Optional, Tuple, Union
+
+import numpy
 
 
-def make_labels_consecutive(labels: npt.NDArray[np.int64], start_id: int = 0) -> npt.NDArray[np.int64]:
+def make_labels_consecutive(
+    labels: numpy.ndarray,
+    start_id: int = 0,
+    ignore_id: Optional[int] = None,
+    inplace: bool = False,
+    return_unique_labels: bool = False,
+) -> Union[numpy.ndarray, Tuple[numpy.ndarray, numpy.ndarray]]:
     """
     Transforms the input labels into consecutive integer labels starting from a given :code:`start_id`.
 
     Args:
         labels: An array of original labels.
         start_id: The starting ID for the consecutive labels. Defaults to zero.
+        ignore_id: A label ID that should not be changed when transforming the labels.
+        inplace: Whether the transformation should be applied inplace to the :code:`labels` array. Defaults to
+            :code:`False`.
+        return_unique_labels: Whether the unique labels after applying the transformation (excluding :code:`ignore_id`)
+            should be returned. Defaults to :code:`False`.
 
     Returns:
-        An array with the transformed consecutive labels.
+        An array with the transformed consecutive labels. If :code:`return_unique_labels` is set to :code:`True`, a
+        tuple of two arrays is returned, where the second array contains the unique labels after the transformation.
     """
 
-    unique_labels = np.unique(labels)
-    unique_labels = np.sort(unique_labels)
-    key = np.arange(0, len(unique_labels))
-    index = np.digitize(labels, unique_labels, right=True)
-    labels = key[index]
-    labels = labels + start_id
+    if len(labels) == 0:
+        if return_unique_labels:
+            return labels, numpy.empty_like(labels)
+        return labels
+
+    if not inplace:
+        labels = labels.copy()
+
+    labels_to_remap: Union[numpy.ndarray, numpy.ma.MaskedArray]
+    if ignore_id is not None:
+        mask = labels != ignore_id
+        labels_to_remap = labels[mask]
+    else:
+        labels_to_remap = labels
+
+    unique_labels = numpy.unique(labels_to_remap)
+    unique_labels = numpy.sort(unique_labels)
+    key = numpy.arange(0, len(unique_labels))
+    index = numpy.digitize(labels_to_remap, unique_labels, right=True)
+    labels_to_remap[:] = key[index]
+    labels_to_remap += start_id
+
+    if ignore_id is not None:
+        labels[mask] = labels_to_remap
+    else:
+        labels[:] = labels_to_remap
+
+    if return_unique_labels:
+        return labels, key + start_id
+
     return labels

--- a/src/pointtorch/operations/numpy/_voxel_downsampling.py
+++ b/src/pointtorch/operations/numpy/_voxel_downsampling.py
@@ -96,7 +96,7 @@ def voxel_downsampling(  # pylint: disable=too-many-locals
         dists_to_voxel_center = np.linalg.norm(shifted_points - voxel_centers[inverse_indices], axis=-1)
 
         dimensions = voxel_indices.max(axis=0) + 1
-        scatter_indices = make_labels_consecutive(
+        scatter_indices: npt.NDArray[np.int64] = make_labels_consecutive(  # type: ignore[assignment]
             np.ravel_multi_index(tuple(voxel_indices[:, dim] for dim in range(voxel_indices.shape[1])), dimensions)
         )
 

--- a/src/pointtorch/operations/torch/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/torch/_make_labels_consecutive.py
@@ -2,25 +2,62 @@
 
 __all__ = ["make_labels_consecutive"]
 
+from typing import Optional, Tuple, Union
+
 import torch
 
 
-def make_labels_consecutive(labels: torch.Tensor, start_id: int = 0) -> torch.Tensor:
+def make_labels_consecutive(
+    labels: torch.Tensor,
+    start_id: int = 0,
+    ignore_id: Optional[int] = None,
+    inplace: bool = False,
+    return_unique_labels: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Transforms the input labels into consecutive integer labels starting from a given :code:`start_id`.
 
     Args:
         labels: An array of original labels.
         start_id: The starting ID for the consecutive labels. Defaults to zero.
+        ignore_id: A label ID that should not be changed when transforming the labels.
+        inplace: Whether the transformation should be applied inplace to the :code:`labels` array. Defaults to
+            :code:`False`.
+        return_unique_labels: Whether the unique labels after applying the transformation (excluding :code:`ignore_id`)
+            should be returned. Defaults to :code:`False`.
 
     Returns:
-        numpy.ndarray: An array with the transformed consecutive labels.
+        A tensor with the transformed consecutive labels. If :code:`return_unique_labels` is set to :code:`True`, a
+        tuple of two tensors is returned, where the second tensor contains the unique labels after the transformation.
     """
 
-    unique_labels = torch.unique(labels)
+    if len(labels) == 0:
+        if return_unique_labels:
+            return labels, torch.empty_like(labels)
+        return labels
+
+    if not inplace:
+        labels = labels.clone()
+
+    if ignore_id is not None:
+        mask = labels != ignore_id
+        labels_to_remap = labels[mask]
+    else:
+        labels_to_remap = labels
+
+    unique_labels = torch.unique(labels_to_remap)
     unique_labels = torch.sort(unique_labels)[0]
     key = torch.arange(0, len(unique_labels), device=labels.device)
-    index = torch.bucketize(labels, unique_labels, right=False)
-    labels = key[index]
-    labels = labels + start_id
+    index = torch.bucketize(labels_to_remap, unique_labels, right=False)
+    labels_to_remap = key[index]
+    labels_to_remap += start_id
+
+    if ignore_id is not None:
+        labels[mask] = labels_to_remap
+    else:
+        labels[:] = labels_to_remap
+
+    if return_unique_labels:
+        return labels, key + start_id
+
     return labels

--- a/src/pointtorch/operations/torch/_voxel_downsampling.py
+++ b/src/pointtorch/operations/torch/_voxel_downsampling.py
@@ -100,7 +100,9 @@ def voxel_downsampling(  # pylint: disable=too-many-locals
     batch_indices = cluster_centers[:, 0]
     cluster_centers = cluster_centers[:, 1:].float() * voxel_size + 0.5 * voxel_size
 
-    scatter_indices = make_labels_consecutive(flattened_indices - flattened_indices.min())
+    scatter_indices: torch.Tensor = make_labels_consecutive(  # type: ignore[assignment]
+        flattened_indices - flattened_indices.min()
+    )
 
     if point_aggregation == "nearest_neighbor" or features is not None and feature_aggregation == "nearest_neighbor":
         point_indices = torch.arange(len(shifted_coords), device=coords.device, dtype=torch.long)

--- a/test/operations/numpy/test_make_labels_consecutive.py
+++ b/test/operations/numpy/test_make_labels_consecutive.py
@@ -1,17 +1,64 @@
 """ Tests for pointtorch.operations.numpy.make_labels_consecutive. """
 
+from typing import Optional
+
 import numpy as np
+import pytest
 
 from pointtorch.operations.numpy import make_labels_consecutive
 
 
-class TestMakeLabelsConsecutive:  # pylint: disable=too-few-public-methods
-    """Tests for pointtorch.operations.numpy.make_labels_consecutive."""
+class TestMakeLabelsConsecutive:
+    """Tests for pointtorch.operations.numpy.make_labels_consecutive"""
 
-    def test_make_labels_consecutive(self):
-        labels = np.array([10, 20, 20, 10, 30])
-        start_id = 5
-        expected_output = np.array([5, 6, 6, 5, 7])
-        output = make_labels_consecutive(labels, start_id)
+    @pytest.mark.parametrize("ignore_id", [-1, None])
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_make_labels_consecutive_empty(self, ignore_id: Optional[int], inplace: bool):
+        remapped_instance_ids, unique_instance_ids = make_labels_consecutive(
+            np.array([], dtype=np.int64), ignore_id=ignore_id, inplace=inplace, return_unique_labels=True
+        )
 
-        np.testing.assert_array_equal(output, expected_output)
+        assert len(remapped_instance_ids) == 0
+        assert len(unique_instance_ids) == 0
+
+    @pytest.mark.parametrize("ignore_id", [-1, None])
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_make_labels_consecutive_no_remapping_necessary(self, ignore_id: Optional[int], inplace: bool):
+        num_instances = 10
+        instance_ids = np.arange(num_instances, dtype=np.int64)
+
+        remapped_instance_ids, unique_instance_ids = make_labels_consecutive(
+            instance_ids, ignore_id=ignore_id, inplace=inplace, return_unique_labels=True
+        )
+
+        np.testing.assert_array_equal(instance_ids, remapped_instance_ids)
+        np.testing.assert_array_equal(instance_ids, unique_instance_ids)
+
+    @pytest.mark.parametrize("ignore_id", [-1, None])
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_make_labels_consecutive_remapping_necessary(self, ignore_id: Optional[int], inplace: bool):
+        offset = 5
+        num_instances = 10
+        instance_ids = np.concatenate(
+            [
+                np.arange(num_instances / 2, dtype=np.int64),
+                np.arange(num_instances / 2, dtype=np.int64),
+                np.arange(offset + num_instances / 2, offset + num_instances, dtype=np.int64),
+            ]
+        )
+
+        expected_remapped_instance_ids = np.concatenate(
+            [
+                np.arange(num_instances / 2, dtype=np.int64),
+                np.arange(num_instances / 2, dtype=np.int64),
+                np.arange(num_instances / 2, num_instances, dtype=np.int64),
+            ]
+        )
+        expected_unique_instance_ids = np.arange(num_instances, dtype=np.int64)
+
+        remapped_instance_ids, unique_instance_ids = make_labels_consecutive(
+            instance_ids, ignore_id=ignore_id, inplace=inplace, return_unique_labels=True
+        )
+
+        np.testing.assert_array_equal(expected_remapped_instance_ids, remapped_instance_ids)
+        np.testing.assert_array_equal(expected_unique_instance_ids, unique_instance_ids)

--- a/test/operations/numpy/test_make_labels_consecutive.py
+++ b/test/operations/numpy/test_make_labels_consecutive.py
@@ -1,4 +1,4 @@
-""" Tests for pointtorch.operations.numpy.make_labels_consecutive. """
+""" Tests for pointtorch.operations.np.make_labels_consecutive. """
 
 from typing import Optional
 
@@ -9,56 +9,69 @@ from pointtorch.operations.numpy import make_labels_consecutive
 
 
 class TestMakeLabelsConsecutive:
-    """Tests for pointtorch.operations.numpy.make_labels_consecutive"""
+    """Tests for pointtorch.operations.numpy.make_labels_consecutive."""
 
     @pytest.mark.parametrize("ignore_id", [-1, None])
     @pytest.mark.parametrize("inplace", [True, False])
-    def test_make_labels_consecutive_empty(self, ignore_id: Optional[int], inplace: bool):
-        remapped_instance_ids, unique_instance_ids = make_labels_consecutive(
-            np.array([], dtype=np.int64), ignore_id=ignore_id, inplace=inplace, return_unique_labels=True
+    @pytest.mark.parametrize("return_unique_labels", [True, False])
+    def test_make_labels_consecutive_empty_input(
+        self, ignore_id: Optional[int], inplace: bool, return_unique_labels: bool
+    ):
+        output = make_labels_consecutive(
+            np.array([], dtype=np.int64),
+            ignore_id=ignore_id,
+            inplace=inplace,
+            return_unique_labels=return_unique_labels,
         )
 
-        assert len(remapped_instance_ids) == 0
-        assert len(unique_instance_ids) == 0
+        if return_unique_labels:
+            transformed_labels, unique_labels = output
+            assert len(unique_labels) == 0
+        else:
+            transformed_labels = output
+
+        assert len(transformed_labels) == 0
+
+    def test_make_labels_consecutive_no_remapping_necessary(self):
+        num_labels = 10
+        labels = np.arange(num_labels, dtype=np.int64)
+
+        transformed_labels, unique_labels = make_labels_consecutive(
+            labels, ignore_id=None, inplace=False, return_unique_labels=True
+        )
+
+        np.testing.assert_array_equal(labels, transformed_labels)
+        np.testing.assert_array_equal(labels, unique_labels)
 
     @pytest.mark.parametrize("ignore_id", [-1, None])
     @pytest.mark.parametrize("inplace", [True, False])
-    def test_make_labels_consecutive_no_remapping_necessary(self, ignore_id: Optional[int], inplace: bool):
-        num_instances = 10
-        instance_ids = np.arange(num_instances, dtype=np.int64)
+    @pytest.mark.parametrize("return_unique_labels", [True, False])
+    def test_make_labels_consecutive_remapping_necessary(
+        self, ignore_id: Optional[int], inplace: bool, return_unique_labels: bool
+    ):
+        labels = np.array([10, -1, 20, 20, 10, 30])
+        start_id = 5
+        if ignore_id is not None:
+            expected_transformed_labels = np.array([5, -1, 6, 6, 5, 7])
+            expected_unique_labels = np.arange(start_id, start_id + 3)
+        else:
+            expected_transformed_labels = np.array([6, 5, 7, 7, 6, 8])
+            expected_unique_labels = np.arange(start_id, start_id + 4)
 
-        remapped_instance_ids, unique_instance_ids = make_labels_consecutive(
-            instance_ids, ignore_id=ignore_id, inplace=inplace, return_unique_labels=True
+        output = make_labels_consecutive(
+            labels, start_id, ignore_id=ignore_id, inplace=inplace, return_unique_labels=return_unique_labels
         )
 
-        np.testing.assert_array_equal(instance_ids, remapped_instance_ids)
-        np.testing.assert_array_equal(instance_ids, unique_instance_ids)
+        if return_unique_labels:
+            transformed_labels, unique_labels = output
 
-    @pytest.mark.parametrize("ignore_id", [-1, None])
-    @pytest.mark.parametrize("inplace", [True, False])
-    def test_make_labels_consecutive_remapping_necessary(self, ignore_id: Optional[int], inplace: bool):
-        offset = 5
-        num_instances = 10
-        instance_ids = np.concatenate(
-            [
-                np.arange(num_instances / 2, dtype=np.int64),
-                np.arange(num_instances / 2, dtype=np.int64),
-                np.arange(offset + num_instances / 2, offset + num_instances, dtype=np.int64),
-            ]
-        )
+            np.testing.assert_array_equal(expected_unique_labels, unique_labels)
+        else:
+            transformed_labels = output
 
-        expected_remapped_instance_ids = np.concatenate(
-            [
-                np.arange(num_instances / 2, dtype=np.int64),
-                np.arange(num_instances / 2, dtype=np.int64),
-                np.arange(num_instances / 2, num_instances, dtype=np.int64),
-            ]
-        )
-        expected_unique_instance_ids = np.arange(num_instances, dtype=np.int64)
+        np.testing.assert_array_equal(expected_transformed_labels, transformed_labels)
 
-        remapped_instance_ids, unique_instance_ids = make_labels_consecutive(
-            instance_ids, ignore_id=ignore_id, inplace=inplace, return_unique_labels=True
-        )
-
-        np.testing.assert_array_equal(expected_remapped_instance_ids, remapped_instance_ids)
-        np.testing.assert_array_equal(expected_unique_instance_ids, unique_instance_ids)
+        if inplace:
+            np.testing.assert_array_equal(labels, transformed_labels)
+        else:
+            assert (labels != transformed_labels).any()

--- a/test/operations/torch/test_make_labels_consecutive.py
+++ b/test/operations/torch/test_make_labels_consecutive.py
@@ -1,19 +1,81 @@
-""" Tests for pointtorch.operations.numpy.make_labels_consecutive. """
+""" Tests for pointtorch.operations.torch.make_labels_consecutive. """
 
-import numpy as np
+from typing import Optional
+
+import numpy
 import pytest
 import torch
 
 from pointtorch.operations.torch import make_labels_consecutive
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"])
-class TestMakeLabelsConsecutive:  # pylint: disable=too-few-public-methods
-    """Tests for pointtorch.operations.numpy.make_labels_consecutive."""
+class TestMakeLabelsConsecutive:
+    """Tests for pointtorch.operations.torch.make_labels_consecutive."""
 
-    def test_make_labels_consecutive(self, device: str):
-        labels = torch.tensor([10, 20, 20, 10, 30], device=device)
+    @pytest.mark.parametrize("device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"])
+    @pytest.mark.parametrize("ignore_id", [-1, None])
+    @pytest.mark.parametrize("inplace", [True, False])
+    @pytest.mark.parametrize("return_unique_labels", [True, False])
+    def test_make_labels_consecutive_empty_input(
+        self, device: str, ignore_id: Optional[int], inplace: bool, return_unique_labels: bool
+    ):
+        output = make_labels_consecutive(
+            torch.tensor([], device=device, dtype=torch.long),
+            ignore_id=ignore_id,
+            inplace=inplace,
+            return_unique_labels=return_unique_labels,
+        )
+
+        if return_unique_labels:
+            transformed_labels, unique_labels = output
+            assert len(unique_labels) == 0
+        else:
+            transformed_labels = output
+
+        assert len(transformed_labels) == 0
+
+    @pytest.mark.parametrize("device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"])
+    def test_make_labels_consecutive_no_remapping_necessary(self, device: str):
+        num_labels = 10
+        labels = torch.arange(num_labels, device=device, dtype=torch.long)
+
+        transformed_labels, unique_labels = make_labels_consecutive(
+            labels, ignore_id=None, inplace=False, return_unique_labels=True
+        )
+
+        numpy.testing.assert_array_equal(labels.cpu().numpy(), transformed_labels.cpu().numpy())
+        numpy.testing.assert_array_equal(labels.cpu().numpy(), unique_labels.cpu().numpy())
+
+    @pytest.mark.parametrize("device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"])
+    @pytest.mark.parametrize("ignore_id", [-1, None])
+    @pytest.mark.parametrize("inplace", [True, False])
+    @pytest.mark.parametrize("return_unique_labels", [True, False])
+    def test_make_labels_consecutive_remapping_necessary(
+        self, device: str, ignore_id: Optional[int], inplace: bool, return_unique_labels: bool
+    ):
+        labels = torch.tensor([10, -1, 20, 20, 10, 30], device=device)
         start_id = 5
-        expected_output = torch.tensor([5, 6, 6, 5, 7], device=device)
-        output = make_labels_consecutive(labels, start_id)
-        np.testing.assert_array_equal(output.cpu().numpy(), expected_output.cpu().numpy())
+        if ignore_id is not None:
+            expected_transformed_labels = numpy.array([5, -1, 6, 6, 5, 7])
+            expected_unique_labels = numpy.arange(start_id, start_id + 3)
+        else:
+            expected_transformed_labels = numpy.array([6, 5, 7, 7, 6, 8])
+            expected_unique_labels = numpy.arange(start_id, start_id + 4)
+
+        output = make_labels_consecutive(
+            labels, start_id, ignore_id=ignore_id, inplace=inplace, return_unique_labels=return_unique_labels
+        )
+
+        if return_unique_labels:
+            transformed_labels, unique_labels = output
+
+            numpy.testing.assert_array_equal(expected_unique_labels, unique_labels.cpu().numpy())
+        else:
+            transformed_labels = output
+
+        numpy.testing.assert_array_equal(expected_transformed_labels, transformed_labels.cpu().numpy())
+
+        if inplace:
+            numpy.testing.assert_array_equal(labels.cpu().numpy(), transformed_labels.cpu().numpy())
+        else:
+            assert (labels != transformed_labels).any()


### PR DESCRIPTION
This pull request refactors the `pointtorch.operations.numpy.make_labels_consecutive` and `pointtorch.operations.torch.make_labels_consecutive` methods to provide a more generic interface.