### PR TITLE
fix: return type of make_labels_consecutive 

### DIFF
--- a/src/pointtorch/operations/numpy/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/numpy/_make_labels_consecutive.py
@@ -48,7 +48,7 @@ def make_labels_consecutive(
 
     unique_labels = np.unique(labels_to_remap)
     unique_labels = np.sort(unique_labels)
-    key = np.arange(0, len(unique_labels))
+    key = np.arange(0, len(unique_labels), dtype=labels.dtype)
     index = np.digitize(labels_to_remap, unique_labels, right=True)
     labels_to_remap[:] = key[index]
     labels_to_remap += start_id

--- a/src/pointtorch/operations/torch/_make_labels_consecutive.py
+++ b/src/pointtorch/operations/torch/_make_labels_consecutive.py
@@ -47,7 +47,7 @@ def make_labels_consecutive(
 
     unique_labels = torch.unique(labels_to_remap)
     unique_labels = torch.sort(unique_labels)[0]
-    key = torch.arange(0, len(unique_labels), device=labels.device)
+    key = torch.arange(0, len(unique_labels), device=labels.device, dtype=labels.dtype)
     index = torch.bucketize(labels_to_remap, unique_labels, right=False)
     labels_to_remap = key[index]
     labels_to_remap += start_id

--- a/test/operations/numpy/test_make_labels_consecutive.py
+++ b/test/operations/numpy/test_make_labels_consecutive.py
@@ -75,3 +75,14 @@ class TestMakeLabelsConsecutive:
             np.testing.assert_array_equal(labels, transformed_labels)
         else:
             assert (labels != transformed_labels).any()
+
+    @pytest.mark.parametrize("scalar_type", [np.int32, np.int64])
+    def test_data_types(self, scalar_type: np.dtype):
+        labels = np.array([0, 2, 3, -1], dtype=scalar_type)
+
+        transformed_labels, unique_labels = make_labels_consecutive(
+            labels, ignore_id=-1, inplace=False, return_unique_labels=True
+        )
+
+        assert transformed_labels.dtype == scalar_type
+        assert unique_labels.dtype == scalar_type

--- a/test/operations/torch/test_make_labels_consecutive.py
+++ b/test/operations/torch/test_make_labels_consecutive.py
@@ -79,3 +79,14 @@ class TestMakeLabelsConsecutive:
             numpy.testing.assert_array_equal(labels.cpu().numpy(), transformed_labels.cpu().numpy())
         else:
             assert (labels != transformed_labels).any()
+
+    @pytest.mark.parametrize("scalar_type", [torch.int, torch.long])
+    def test_data_types(self, scalar_type: torch.dtype):
+        labels = torch.tensor([0, 2, 3, -1], dtype=scalar_type)
+
+        transformed_labels, unique_labels = make_labels_consecutive(
+            labels, ignore_id=-1, inplace=False, return_unique_labels=True
+        )
+
+        assert transformed_labels.dtype == scalar_type
+        assert unique_labels.dtype == scalar_type


### PR DESCRIPTION
This pull request adapts `pointtorch.operations.numpy.make_labels_consecutive` and `pointtorch.operations.torch.make_labels_consecutive`, ensuring that the unique labels returned by the method have the same data type as the input labels.