### PR TITLE
feat: load specified number of rows from point cloud file

### DIFF
--- a/src/pointtorch/core/_read.py
+++ b/src/pointtorch/core/_read.py
@@ -7,13 +7,16 @@ from pointtorch.core._point_cloud import PointCloud
 from pointtorch.io import PointCloudReader
 
 
-def read(file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None) -> PointCloud:
+def read(
+    file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+) -> PointCloud:
     """
     Method for reading point cloud files.
 
     Args:
         file_path: Path of the point cloud file to be read.
         columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+        num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
     Returns:
         Point cloud object.
@@ -23,7 +26,7 @@ def read(file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = Non
     """
 
     reader = PointCloudReader()
-    point_cloud_data = reader.read(file_path, columns=columns)
+    point_cloud_data = reader.read(file_path, columns=columns, num_rows=num_rows)
     point_cloud = PointCloud(
         point_cloud_data.data,
         identifier=point_cloud_data.identifier,

--- a/src/pointtorch/io/_base_point_cloud_reader.py
+++ b/src/pointtorch/io/_base_point_cloud_reader.py
@@ -57,7 +57,7 @@ class BasePointCloudReader(abc.ABC):
                 if coord not in columns:
                     columns.insert(idx, coord)
 
-        point_cloud_df = self._read_points(file_path, columns=columns)
+        point_cloud_df = self._read_points(file_path, columns=columns, num_rows=num_rows)
         (x_max_resolution, y_max_resolution, z_max_resolution) = self._read_max_resolutions(file_path)
 
         return PointCloudIoData(

--- a/src/pointtorch/io/_base_point_cloud_reader.py
+++ b/src/pointtorch/io/_base_point_cloud_reader.py
@@ -21,13 +21,16 @@ class BasePointCloudReader(abc.ABC):
             File formats supported by the point cloud file reader.
         """
 
-    def read(self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None) -> PointCloudIoData:
+    def read(
+        self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> PointCloudIoData:
         """
         Reads a point cloud file.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud object.
@@ -66,13 +69,16 @@ class BasePointCloudReader(abc.ABC):
         )
 
     @abc.abstractmethod
-    def _read_points(self, file_path: pathlib.Path, columns: Optional[List[str]] = None) -> pd.DataFrame:
+    def _read_points(
+        self, file_path: pathlib.Path, columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> pd.DataFrame:
         """
         Reads point data from a point cloud file. This method has to be overriden by child classes.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud data.

--- a/src/pointtorch/io/_csv_reader.py
+++ b/src/pointtorch/io/_csv_reader.py
@@ -22,13 +22,16 @@ class CsvReader(BasePointCloudReader):
 
         return ["csv", "txt"]
 
-    def read(self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None) -> PointCloudIoData:
+    def read(
+        self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> PointCloudIoData:
         """
         Reads a point cloud file.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud object.
@@ -40,20 +43,23 @@ class CsvReader(BasePointCloudReader):
         # class.
         return super().read(file_path, columns=columns)
 
-    def _read_points(self, file_path: pathlib.Path, columns: Optional[List[str]] = None) -> pd.DataFrame:
+    def _read_points(
+        self, file_path: pathlib.Path, columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> pd.DataFrame:
         """
         Reads point data from a point cloud file in csv or txt format.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud data.
         """
 
         file_format = file_path.suffix.lstrip(".")
-        return pd.read_csv(file_path, usecols=columns, sep="," if file_format == "csv" else " ")
+        return pd.read_csv(file_path, usecols=columns, sep="," if file_format == "csv" else " ", nrows=num_rows)
 
     @staticmethod
     def _read_max_resolutions(file_path: pathlib.Path) -> Tuple[float, float, float]:

--- a/src/pointtorch/io/_hdf_reader.py
+++ b/src/pointtorch/io/_hdf_reader.py
@@ -65,7 +65,9 @@ class HdfReader(BasePointCloudReader):
             start = 0
             stop = num_rows
 
-        return pd.read_hdf(file_path, columns=columns, key="point_cloud", start=start, stop=stop)  # type: ignore[return-value]
+        return pd.read_hdf(  # type: ignore[return-value]
+            file_path, columns=columns, key="point_cloud", start=start, stop=stop
+        )
 
     @staticmethod
     def _read_max_resolutions(file_path: pathlib.Path) -> Tuple[float, float, float]:

--- a/src/pointtorch/io/_hdf_reader.py
+++ b/src/pointtorch/io/_hdf_reader.py
@@ -23,13 +23,16 @@ class HdfReader(BasePointCloudReader):
 
         return ["h5", "hdf"]
 
-    def read(self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None) -> PointCloudIoData:
+    def read(
+        self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> PointCloudIoData:
         """
         Reads a point cloud file.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud object.
@@ -41,19 +44,28 @@ class HdfReader(BasePointCloudReader):
         # class.
         return super().read(file_path, columns=columns)
 
-    def _read_points(self, file_path: pathlib.Path, columns: Optional[List[str]] = None) -> pd.DataFrame:
+    def _read_points(
+        self, file_path: pathlib.Path, columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> pd.DataFrame:
         """
         Reads point data from a point cloud file in h5 and hdf format.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud data.
         """
 
-        return pd.read_hdf(file_path, columns=columns, key="point_cloud")  # type: ignore[return-value]
+        start = None
+        stop = None
+        if num_rows is not None:
+            start = 0
+            stop = num_rows
+
+        return pd.read_hdf(file_path, columns=columns, key="point_cloud", start=start, stop=stop)  # type: ignore[return-value]
 
     @staticmethod
     def _read_max_resolutions(file_path: pathlib.Path) -> Tuple[float, float, float]:

--- a/src/pointtorch/io/_point_cloud_reader.py
+++ b/src/pointtorch/io/_point_cloud_reader.py
@@ -27,13 +27,16 @@ class PointCloudReader:
         """
         return list(self._readers.keys())
 
-    def read(self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None) -> PointCloudIoData:
+    def read(
+        self, file_path: Union[str, pathlib.Path], columns: Optional[List[str]] = None, num_rows: Optional[int] = None
+    ) -> PointCloudIoData:
         """
         Reads a point cloud file.
 
         Args:
             file_path: Path of the point cloud file to be read.
             columns: Name of the point cloud columns to be read. The x, y, and z columns are always read.
+            num_rows: Number of rows to read. If set to :code:`None`, all rows are read. Defaults to :code:`None`.
 
         Returns:
             Point cloud object.
@@ -48,4 +51,4 @@ class PointCloudReader:
         file_format = file_path.suffix.lstrip(".")
         if file_format not in self.supported_file_formats():
             raise ValueError(f"The {file_format} format is not supported by the point cloud reader.")
-        return self._readers[file_format].read(file_path, columns=columns)
+        return self._readers[file_format].read(file_path, columns=columns, num_rows=num_rows)

--- a/test/io/test_csv_reader.py
+++ b/test/io/test_csv_reader.py
@@ -32,9 +32,16 @@ class TestCsvReader:
 
     @pytest.mark.parametrize("file_format", ["csv", "txt"])
     @pytest.mark.parametrize("columns", [None, ["classification"], ["x", "y", "z", "classification"]])
+    @pytest.mark.parametrize("num_rows", [None, 2])
     @pytest.mark.parametrize("use_pathlib", [True, False])
     def test_read(
-        self, csv_reader: CsvReader, cache_dir: str, file_format: str, columns: Optional[List[str]], use_pathlib: bool
+        self,
+        csv_reader: CsvReader,
+        cache_dir: str,
+        file_format: str,
+        columns: Optional[List[str]],
+        num_rows: Optional[int],
+        use_pathlib: bool,
     ):
         point_cloud_df = pd.DataFrame(
             [[0, 0, 0, 1, 122], [1, 1, 1, 0, 23]], columns=["x", "y", "z", "classification", "instance"]
@@ -44,14 +51,14 @@ class TestCsvReader:
             file_path = pathlib.Path(file_path)
         point_cloud_df.to_csv(file_path, index=False, sep="," if file_format == "csv" else " ")
 
-        read_point_cloud = csv_reader.read(file_path, columns=columns)
+        read_point_cloud = csv_reader.read(file_path, columns=columns, num_rows=num_rows)
 
         if columns is not None:
             # Test that the x, y, and z columns are always read.
             for idx, coord in enumerate(["x", "y", "z"]):
                 if coord not in columns:
                     columns.insert(idx, coord)
-            point_cloud_df = point_cloud_df[columns]
+            point_cloud_df = point_cloud_df[columns].head(num_rows)
 
         assert (point_cloud_df.to_numpy() == read_point_cloud.data.to_numpy()).all()
 

--- a/test/io/test_hdf_reader.py
+++ b/test/io/test_hdf_reader.py
@@ -31,6 +31,7 @@ class TestHdfReader:
 
     @pytest.mark.parametrize("file_format", ["h5", "hdf"])
     @pytest.mark.parametrize("columns", [None, ["classification"], ["x", "y", "z", "classification"]])
+    @pytest.mark.parametrize("num_rows", [None, 2])
     @pytest.mark.parametrize("use_pathlib", [True, False])
     def test_read(
         self,
@@ -39,6 +40,7 @@ class TestHdfReader:
         cache_dir: str,
         file_format: str,
         columns: Optional[List[str]],
+        num_rows: Optional[int],
         use_pathlib: bool,
     ):
         point_cloud_df = pd.DataFrame(
@@ -52,14 +54,14 @@ class TestHdfReader:
 
         hdf_writer.write(point_cloud, file_path)
 
-        read_point_cloud = hdf_reader.read(file_path, columns=columns)
+        read_point_cloud = hdf_reader.read(file_path, columns=columns, num_rows=num_rows)
 
         if columns is not None:
             # Test that the x, y, and z columns are always read.
             for idx, coord in enumerate(["x", "y", "z"]):
                 if coord not in columns:
                     columns.insert(idx, coord)
-            point_cloud_df = point_cloud_df[columns]
+            point_cloud_df = point_cloud_df[columns].head(num_rows)
 
         assert (point_cloud_df.to_numpy() == read_point_cloud.data.to_numpy()).all()
         assert "test" == read_point_cloud.identifier

--- a/test/io/test_las_reader.py
+++ b/test/io/test_las_reader.py
@@ -31,6 +31,7 @@ class TestLasReader:
 
     @pytest.mark.parametrize("file_format", ["las", "laz"])
     @pytest.mark.parametrize("columns", [None, ["classification"], ["x", "y", "z", "classification"]])
+    @pytest.mark.parametrize("num_rows", [None, 2])
     @pytest.mark.parametrize("use_pathlib", [True, False])
     def test_read(
         self,
@@ -39,6 +40,7 @@ class TestLasReader:
         cache_dir: str,
         file_format: str,
         columns: Optional[List[str]],
+        num_rows: Optional[int],
         use_pathlib: bool,
     ):
         point_cloud_df = pd.DataFrame(
@@ -56,9 +58,9 @@ class TestLasReader:
             for idx, coord in enumerate(["x", "y", "z"]):
                 if coord not in columns:
                     columns.insert(idx, coord)
-            point_cloud_df = point_cloud_df[columns]
+            point_cloud_df = point_cloud_df[columns].head(num_rows)
 
-        read_point_cloud_data = las_reader.read(file_path, columns=columns)
+        read_point_cloud_data = las_reader.read(file_path, columns=columns, num_rows=num_rows)
 
         assert (point_cloud_df.to_numpy() == read_point_cloud_data.data.to_numpy()).all()
 


### PR DESCRIPTION
This pull request adds a `num_rows` parameter to the point cloud file readers, allowing to read only a certain number of rows from a point cloud file.