### PR TITLE
fix: load specified number of rows from point cloud file

### DIFF
--- a/src/pointtorch/io/_csv_reader.py
+++ b/src/pointtorch/io/_csv_reader.py
@@ -41,7 +41,7 @@ class CsvReader(BasePointCloudReader):
         """
         # The method from the base is called explicitly so that the read method appears in the documentation of this
         # class.
-        return super().read(file_path, columns=columns)
+        return super().read(file_path, columns=columns, num_rows=num_rows)
 
     def _read_points(
         self, file_path: pathlib.Path, columns: Optional[List[str]] = None, num_rows: Optional[int] = None

--- a/src/pointtorch/io/_hdf_reader.py
+++ b/src/pointtorch/io/_hdf_reader.py
@@ -42,7 +42,7 @@ class HdfReader(BasePointCloudReader):
         """
         # The method from the base is called explicitly so that the read method appears in the documentation of this
         # class.
-        return super().read(file_path, columns=columns)
+        return super().read(file_path, columns=columns, num_rows=num_rows)
 
     def _read_points(
         self, file_path: pathlib.Path, columns: Optional[List[str]] = None, num_rows: Optional[int] = None

--- a/src/pointtorch/io/_las_writer.py
+++ b/src/pointtorch/io/_las_writer.py
@@ -126,9 +126,7 @@ class LasWriter(BasePointCloudWriter):
             las_data.update_header()
             las_data[column_name] = point_cloud[column_name]
 
-        print("crs", crs)
         if crs is not None:
-            print("crs", CRS.from_string(crs))
             las_data.header.add_crs(CRS.from_string(crs))
 
         las_data.write(file_path)

--- a/test/io/test_csv_reader.py
+++ b/test/io/test_csv_reader.py
@@ -44,7 +44,7 @@ class TestCsvReader:
         use_pathlib: bool,
     ):
         point_cloud_df = pd.DataFrame(
-            [[0, 0, 0, 1, 122], [1, 1, 1, 0, 23]], columns=["x", "y", "z", "classification", "instance"]
+            [[0, 0, 0, 1, 12], [1, 1, 1, 0, 23], [2, 2, 2, 0, 1]], columns=["x", "y", "z", "classification", "instance"]
         )
         file_path: Union[str, pathlib.Path] = os.path.join(cache_dir, f"test_point_cloud.{file_format}")
         if use_pathlib:
@@ -58,7 +58,9 @@ class TestCsvReader:
             for idx, coord in enumerate(["x", "y", "z"]):
                 if coord not in columns:
                     columns.insert(idx, coord)
-            point_cloud_df = point_cloud_df[columns].head(num_rows)
+            point_cloud_df = point_cloud_df[columns]
+        if num_rows is not None:
+            point_cloud_df = point_cloud_df.head(num_rows)
 
         assert (point_cloud_df.to_numpy() == read_point_cloud.data.to_numpy()).all()
 

--- a/test/io/test_hdf_reader.py
+++ b/test/io/test_hdf_reader.py
@@ -45,7 +45,7 @@ class TestHdfReader:
         use_pathlib: bool,
     ):
         point_cloud_df = pd.DataFrame(
-            [[0, 0, 0, 1, 122], [1, 1, 1, 0, 23]], columns=["x", "y", "z", "classification", "instance"]
+            [[0, 0, 0, 1, 12], [1, 1, 1, 0, 23], [2, 2, 2, 0, 1]], columns=["x", "y", "z", "classification", "instance"]
         )
         point_cloud = PointCloudIoData(point_cloud_df)
         point_cloud.identifier = "test"
@@ -62,7 +62,9 @@ class TestHdfReader:
             for idx, coord in enumerate(["x", "y", "z"]):
                 if coord not in columns:
                     columns.insert(idx, coord)
-            point_cloud_df = point_cloud_df[columns].head(num_rows)
+            point_cloud_df = point_cloud_df[columns]
+        if num_rows is not None:
+            point_cloud_df = point_cloud_df.head(num_rows)
 
         assert (point_cloud_df.to_numpy() == read_point_cloud.data.to_numpy()).all()
         assert "test" == read_point_cloud.identifier

--- a/test/io/test_las_reader.py
+++ b/test/io/test_las_reader.py
@@ -45,7 +45,7 @@ class TestLasReader:
         use_pathlib: bool,
     ):
         point_cloud_df = pd.DataFrame(
-            [[0, 0, 0, 1, 122], [1, 1, 1, 0, 23]], columns=["x", "y", "z", "classification", "instance"]
+            [[0, 0, 0, 1, 12], [1, 1, 1, 0, 23], [2, 2, 2, 0, 1]], columns=["x", "y", "z", "classification", "instance"]
         )
         point_cloud_data = PointCloudIoData(point_cloud_df)
         file_path: Union[str, pathlib.Path] = os.path.join(cache_dir, f"test_point_cloud.{file_format}")
@@ -59,7 +59,9 @@ class TestLasReader:
             for idx, coord in enumerate(["x", "y", "z"]):
                 if coord not in columns:
                     columns.insert(idx, coord)
-            point_cloud_df = point_cloud_df[columns].head(num_rows)
+            point_cloud_df = point_cloud_df[columns]
+        if num_rows is not None:
+            point_cloud_df = point_cloud_df.head(num_rows)
 
         read_point_cloud_data = las_reader.read(file_path, columns=columns, num_rows=num_rows)
 


### PR DESCRIPTION
This pull request fixes the feature introduced in #26. The implementation in #26 did not work correctly because the `num_rows` parameter was not passed trough to the readers `_read_points` method.