### PR TITLE
refactor: remove torch dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,6 @@ dependencies = [
     "pyproj>=3.4.0, <4.0.0",
     "scikit-learn>=1.2.0, <2.0.0",
     "tables>=3.8.0, <4.0.0",
-    "torch>=2.0.0, <=2.5.0",
-    "torch-cluster>=1.6.0, <2.0.0",
-    "torch-scatter>=2.0.2, <3.0.0",
     "tqdm>=4.60.0, <5.0.0",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
remove torch, torch-cluster, torch-scatter from pyproject.toml since these dependencies must be installed manually