### PR TITLE
refactor: data PCD reader and writer

### DIFF
--- a/src/pointtorch/io/_pcd_reader.py
+++ b/src/pointtorch/io/_pcd_reader.py
@@ -5,8 +5,8 @@ __all__ = ["PcdReader"]
 import pathlib
 from typing import List, Optional, Tuple, Union
 
-from pypcd.pypcd import PointCloud
 import pandas as pd
+from pypcd.pypcd import PointCloud
 
 from ._base_point_cloud_reader import BasePointCloudReader
 from ._point_cloud_io_data import PointCloudIoData

--- a/src/pointtorch/io/_pcd_writer.py
+++ b/src/pointtorch/io/_pcd_writer.py
@@ -14,7 +14,15 @@ from ._point_cloud_io_data import PointCloudIoData
 
 
 class PcdWriter(BasePointCloudWriter):
-    """Point cloud file writer for pcd files."""
+    """Point cloud file writer for pcd files.
+
+    Args:
+        file_type: File type to use: :code:`"ascii"`, :code:`"binary"`, :code:`"binary_compressed"`. Defaults to
+            :code:`"binary_compressed"`.
+    """
+
+    def __init__(self, file_type: Literal["ascii", "binary", "binary_compressed"] = "binary_compressed"):
+        self._file_type = file_type
 
     def supported_file_formats(self) -> List[str]:
         """
@@ -53,7 +61,6 @@ class PcdWriter(BasePointCloudWriter):
         x_max_resolution: Optional[float] = None,
         y_max_resolution: Optional[float] = None,
         z_max_resolution: Optional[float] = None,
-        file_type: Literal["ascii", "binary", "binary_compressed"] = "binary_compressed",
     ) -> None:
         """
         Writes a point cloud to a file. The point coordinates are always stored as 32 bit floating point numbers, as
@@ -68,8 +75,6 @@ class PcdWriter(BasePointCloudWriter):
             x_max_resolution: Maximum resolution of the point cloud's x-coordinates in meter. Defaults to :code:`None`.
             y_max_resolution: Maximum resolution of the point cloud's y-coordinates in meter. Defaults to :code:`None`.
             z_max_resolution: Maximum resolution of the point cloud's z-coordinates in meter. Defaults to :code:`None`.
-            file_type: File type to use: :code:`"ascii"`, :code:`"binary"`, :code:`"binary_compressed"`. Defaults to
-                :code:`"binary_compressed"`.
         """
 
         dtypes = dict(point_cloud.dtypes)
@@ -91,9 +96,9 @@ class PcdWriter(BasePointCloudWriter):
             "height": 1,
             "points": len(point_cloud),
             "viewpoint": "0 0 0 1 0 0 0",
-            "data": file_type,
+            "data": self._file_type,
             "count": [1 for _ in range(len(point_cloud.columns))],
         }
 
         point_cloud_pypcd = PointCloud(metadata, point_cloud_structured_array)
-        point_cloud_pypcd.save_pcd(file_path, compression=file_type)
+        point_cloud_pypcd.save_pcd(file_path, compression=self._file_type)

--- a/src/pointtorch/io/_pcd_writer.py
+++ b/src/pointtorch/io/_pcd_writer.py
@@ -56,7 +56,8 @@ class PcdWriter(BasePointCloudWriter):
         file_type: Literal["ascii", "binary", "binary_compressed"] = "binary_compressed",
     ) -> None:
         """
-        Writes a point cloud to a file.
+        Writes a point cloud to a file. The point coordinates are always stored as 32 bit floating point numbers, as
+        some PCD readers require this.
 
         Args:
             point_cloud: Point cloud to be written.

--- a/src/pointtorch/io/_pcd_writer.py
+++ b/src/pointtorch/io/_pcd_writer.py
@@ -4,6 +4,7 @@ __all__ = ["PcdWriter"]
 
 import pathlib
 from typing import List, Literal, Optional, Union
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -78,6 +79,10 @@ class PcdWriter(BasePointCloudWriter):
         """
 
         dtypes = dict(point_cloud.dtypes)
+        if dtypes["x"] != np.float32 or dtypes["y"] != np.float32 or dtypes["z"] != np.float32:
+            warnings.warn(
+                "Converting xyz to 32 bit floating point numbers since pcd only supports coordinates of this type."
+            )
         dtypes["x"] = np.float32
         dtypes["y"] = np.float32
         dtypes["z"] = np.float32

--- a/src/pointtorch/io/_pcd_writer.py
+++ b/src/pointtorch/io/_pcd_writer.py
@@ -71,7 +71,12 @@ class PcdWriter(BasePointCloudWriter):
                 :code:`"binary_compressed"`.
         """
 
-        records = point_cloud.to_records(index=False)
+        dtypes = dict(point_cloud.dtypes)
+        dtypes["x"] = np.float32
+        dtypes["y"] = np.float32
+        dtypes["z"] = np.float32
+
+        records = point_cloud.to_records(index=False, column_dtypes=dtypes)
         point_cloud_structured_array = np.array(records, dtype=records.dtype.descr)
 
         type_mapping = dict(numpy_pcd_type_mappings)
@@ -79,8 +84,8 @@ class PcdWriter(BasePointCloudWriter):
         metadata = {
             "version": "0.7",
             "fields": point_cloud.columns,
-            "type": [type_mapping[point_cloud[column].dtype][0] for column in point_cloud.columns],
-            "size": [type_mapping[point_cloud[column].dtype][1] for column in point_cloud.columns],
+            "type": [type_mapping[point_cloud_structured_array[column].dtype][0] for column in point_cloud.columns],
+            "size": [type_mapping[point_cloud_structured_array[column].dtype][1] for column in point_cloud.columns],
             "width": len(point_cloud),
             "height": 1,
             "points": len(point_cloud),

--- a/src/pointtorch/io/_pcd_writer.py
+++ b/src/pointtorch/io/_pcd_writer.py
@@ -14,7 +14,7 @@ from ._point_cloud_io_data import PointCloudIoData
 
 
 class PcdWriter(BasePointCloudWriter):
-    """Point cloud file writer for cpcd files."""
+    """Point cloud file writer for pcd files."""
 
     def supported_file_formats(self) -> List[str]:
         """

--- a/test/io/test_pcd_writer.py
+++ b/test/io/test_pcd_writer.py
@@ -32,14 +32,11 @@ class TestPcdWriter:
 
     @pytest.mark.parametrize("columns", [None, ["classification"], ["x", "y", "z", "classification"]])
     @pytest.mark.parametrize("use_pathlib", [True, False])
+    @pytest.mark.parametrize("file_type", ["ascii", "binary", "binary_compressed"])
     def test_writer(
-        self,
-        pcd_reader: PcdReader,
-        pcd_writer: PcdWriter,
-        cache_dir: str,
-        columns: Optional[list[str]],
-        use_pathlib: bool,
+        self, pcd_reader: PcdReader, cache_dir: str, columns: Optional[list[str]], use_pathlib: bool, file_type: str
     ):
+        pcd_writer = PcdWriter(file_type=file_type)
         point_cloud_df = pd.DataFrame(
             [[0, 0, 0, 1, 122, 56, 28, 245], [1, 1, 1, 0, 23, 128, 128, 128]],
             columns=["x", "y", "z", "classification", "instance", "r", "g", "b"],

--- a/test/io/test_pcd_writer.py
+++ b/test/io/test_pcd_writer.py
@@ -5,6 +5,7 @@ import pathlib
 import shutil
 from typing import Optional, Union
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -62,6 +63,10 @@ class TestPcdWriter:
 
         expected_columns = sorted(point_cloud_df.columns)
         columns = sorted(read_point_cloud_data.data.columns)
+
+        assert read_point_cloud_data.data["x"].dtype == np.float32
+        assert read_point_cloud_data.data["y"].dtype == np.float32
+        assert read_point_cloud_data.data["z"].dtype == np.float32
 
         assert expected_columns == columns
         assert (

--- a/test/io/test_pcd_writer.py
+++ b/test/io/test_pcd_writer.py
@@ -40,7 +40,10 @@ class TestPcdWriter:
         point_cloud_df = pd.DataFrame(
             [[0, 0, 0, 1, 122, 56, 28, 245], [1, 1, 1, 0, 23, 128, 128, 128]],
             columns=["x", "y", "z", "classification", "instance", "r", "g", "b"],
+            dtype=np.int32,
         )
+        point_cloud_df[["x", "y", "z"]] = point_cloud_df[["x", "y", "z"]].astype(np.float64)
+        point_cloud_df["instance"] = point_cloud_df["instance"].astype(np.int64)
         point_cloud_data = PointCloudIoData(point_cloud_df)
         file_path: Union[str, pathlib.Path] = os.path.join(cache_dir, "test_point_cloud.pcd")
         if use_pathlib:
@@ -61,14 +64,16 @@ class TestPcdWriter:
         expected_columns = sorted(point_cloud_df.columns)
         columns = sorted(read_point_cloud_data.data.columns)
 
-        assert read_point_cloud_data.data["x"].dtype == np.float32
-        assert read_point_cloud_data.data["y"].dtype == np.float32
-        assert read_point_cloud_data.data["z"].dtype == np.float32
-
         assert expected_columns == columns
         assert (
             point_cloud_df[expected_columns].to_numpy() == read_point_cloud_data.data[expected_columns].to_numpy()
         ).all()
+
+        for column in point_cloud_df.columns:
+            if column in ["x", "y", "z"]:
+                assert read_point_cloud_data.data[column].dtype == np.float32
+            else:
+                assert read_point_cloud_data.data[column].dtype == point_cloud_df[column].dtype
 
     def test_write_unsupported_format(self, pcd_writer: PcdWriter, cache_dir: str):
         point_cloud_data = PointCloudIoData(pd.DataFrame([[0, 0, 0]], columns=["x", "y", "z"]))


### PR DESCRIPTION
Refactors the `pointtorch.io.PcdReader` and `pointtorch.io.PcdWriter` classes. In particular, the data type handling for XYZ coordinates is changed: The PCD file format usually stores the coordinate values as 32-bit floating point numbers. As some PCD readers require the coordinates to be 32-bit floating point numbers, this pull request adapts the `pointtorch.io.PcdWriter` class to always store the coordinates as 32-bit values.