### PR TITLE
feat: operation to resolve instance overlaps

### DIFF
--- a/src/pointtorch/operations/numpy/__init__.py
+++ b/src/pointtorch/operations/numpy/__init__.py
@@ -6,6 +6,7 @@ Point cloud processing operations for the use with `numpy arrays
 from ._fit_oriented_bounding_box import *
 from ._make_labels_consecutive import *
 from ._non_max_suppression import *
+from ._resolve_instance_overlaps import *
 from ._voxel_downsampling import *
 
 __all__ = [name for name in globals().keys() if not name.startswith("_")]

--- a/src/pointtorch/operations/numpy/_non_max_suppression.py
+++ b/src/pointtorch/operations/numpy/_non_max_suppression.py
@@ -3,9 +3,10 @@
 __all__ = ["non_max_suppression", "compute_pairwise_ious"]
 
 import numpy as np
+import numpy.typing as npt
 
 
-def compute_pairwise_ious(instances: np.ndarray, instance_sizes: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+def compute_pairwise_ious(instances: npt.NDArray, instance_sizes: npt.NDArray, eps: float = 1e-8) -> npt.NDArray:
     r"""
     Computes pairwise intersection over union (IoU) between instances.
 
@@ -43,7 +44,7 @@ def compute_pairwise_ious(instances: np.ndarray, instance_sizes: np.ndarray, eps
     return ious
 
 
-def non_max_suppression(ious: np.ndarray, scores: np.ndarray, iou_threshold: float) -> np.ndarray:
+def non_max_suppression(ious: npt.NDArray, scores: npt.NDArray, iou_threshold: float) -> npt.NDArray:
     r"""
     Non-maximum suppression operation for instance detection.
 

--- a/src/pointtorch/operations/numpy/_resolve_instance_overlaps.py
+++ b/src/pointtorch/operations/numpy/_resolve_instance_overlaps.py
@@ -1,0 +1,61 @@
+"""Resolution of overlaps between segmented instances."""
+
+__all__ = ["resolve_instance_overlaps"]
+
+from typing import Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+def resolve_instance_overlaps(
+    instances: npt.NDArray, instance_sizes: npt.NDArray, scores: npt.NDArray
+) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+    r"""
+    Resolves overlaps between instances by assigning points that are included in multiple instances to the instance
+    with the highest score.
+
+    Args:
+        instances: List of instances where each instance is represented by a set of point indices that are stored
+            consecutively.
+        instance_sizes: Number of points belonging to each instance.
+        scores: Confidence score for each instance.
+
+    Returns:
+        Tuple of two arrays: The first represents the updated instance assignments in the same format as
+            :code:`instances`. The second contains the indices indicating to which instance each index in the first
+            array belongs. The third contains the number of points belonging to each updated instance.
+
+    Shape:
+        - :attr:`instances`: :math:`(N_1 + ... + N_I)`
+        - :attr:`instance_sizes`: :math:`(I)`
+        - Output: :math:`(N_1' + ... + N_I')`, :math:`(N_1' + ... + N_I')`, and :math:`(I')`
+
+          | where
+          |
+          | :math:`I = \text{ number of instances before the filtering}`
+          | :math:`I' = \text{ number of instances after the filtering}`
+          | :math:`N_i = \text{ number of points belonging to the i-th instance before the filtering}`
+          | :math:`N_i' = \text{ number of points belonging to the i-th instance after the filtering}`
+    """
+
+    sorted_indices = scores.argsort()[::-1]
+
+    is_assigned = np.zeros(instances.max() + 1, dtype=bool)
+
+    split_instances = np.split(instances, instance_sizes.cumsum()[:-1])
+
+    new_instances = []
+    new_instance_sizes = []
+
+    for i in sorted_indices:
+        instance = split_instances[i]
+        instance = instance[~is_assigned[instance]]
+        is_assigned[instance] = True
+
+        if len(instance) > 0:
+            new_instances.append(instance)
+            new_instance_sizes.append(len(instance))
+
+    new_instance_batch_indices = np.repeat(np.arange(len(new_instance_sizes), dtype=np.int64), new_instance_sizes)
+    return np.concatenate(new_instances), new_instance_batch_indices, np.array(new_instance_sizes, dtype=np.int64)

--- a/test/operations/numpy/test_non_maximum_suppression.py
+++ b/test/operations/numpy/test_non_maximum_suppression.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from pointtorch.operations.numpy import compute_pairwise_ious, non_max_suppression, resolve_instance_overlaps
+from pointtorch.operations.numpy import compute_pairwise_ious, non_max_suppression
 
 
 class TestNonMaximumSuppression:

--- a/test/operations/numpy/test_non_maximum_suppression.py
+++ b/test/operations/numpy/test_non_maximum_suppression.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from pointtorch.operations.numpy import compute_pairwise_ious, non_max_suppression
+from pointtorch.operations.numpy import compute_pairwise_ious, non_max_suppression, resolve_instance_overlaps
 
 
 class TestNonMaximumSuppression:

--- a/test/operations/numpy/test_resolve_instance_overlaps.py
+++ b/test/operations/numpy/test_resolve_instance_overlaps.py
@@ -5,7 +5,7 @@ import numpy as np
 from pointtorch.operations.numpy import resolve_instance_overlaps
 
 
-class TestResolveInstanceOverlaps:
+class TestResolveInstanceOverlaps:  # pylint: disable = too-few-public-methods
     """Tests for pointtorch.operations.numpy.resolve_instance_overlaps."""
 
     def test_resolve_instance_overlaps(self):

--- a/test/operations/numpy/test_resolve_instance_overlaps.py
+++ b/test/operations/numpy/test_resolve_instance_overlaps.py
@@ -1,0 +1,26 @@
+"""Tests for pointtorch.operations.numpy.resolve_instance_overlaps."""
+
+import numpy as np
+
+from pointtorch.operations.numpy import resolve_instance_overlaps
+
+
+class TestResolveInstanceOverlaps:
+    """Tests for pointtorch.operations.numpy.resolve_instance_overlaps."""
+
+    def test_resolve_instance_overlaps(self):
+        instances = np.array([0, 1, 0, 1, 2, 3, 4, 2, 4, 5, 6, 10, 12], dtype=np.int64)
+        instance_sizes = np.array([2, 5, 4, 2], dtype=np.int64)
+        scores = np.array([0.5, 0.9, 0.4, 0.8], dtype=np.float32)
+
+        expected_filtered_instances = np.array([0, 1, 2, 3, 4, 10, 12, 5, 6], dtype=np.int64)
+        filtere_instance_batch_indices = np.array([0, 0, 0, 0, 0, 1, 1, 2, 2], dtype=np.int64)
+        expected_filtered_instance_sizes = np.array([5, 2, 2], dtype=np.int64)
+
+        filtered_instances, filtere_instance_batch_indices, filtered_instance_sizes = resolve_instance_overlaps(
+            instances, instance_sizes, scores
+        )
+
+        np.testing.assert_array_equal(expected_filtered_instances, filtered_instances)
+        np.testing.assert_array_equal(filtere_instance_batch_indices, filtere_instance_batch_indices)
+        np.testing.assert_array_equal(expected_filtered_instance_sizes, filtered_instance_sizes)


### PR DESCRIPTION
This pull request adds the operation `pointtorch.operations.numpy.resolve_instance_overlaps`. The method resolves overlaps between segmented instances by assigning points that are included in multiple instances to the instance with the highest score.