### PR TITLE
refactor: unzip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "scikit-learn>=1.2.0, <2.0.0",
     "tables>=3.8.0, <4.0.0",
     "tqdm>=4.60.0, <5.0.0",
+    "zipfile-deflate64>=0.2.0, <1.0.0",
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/pointtorch/io/_unzip.py
+++ b/src/pointtorch/io/_unzip.py
@@ -33,6 +33,7 @@ def unzip(
 
     Raises:
         FileNotFoundError: If the zip file does not exist.
+        KeyError: If :code:`items` contains items not existing in the zip archive.
     """
     if isinstance(dest_path, str):
         dest_path = pathlib.Path(dest_path)
@@ -43,6 +44,12 @@ def unzip(
             prog_bar = tqdm(desc=progress_bar_desc, unit="B", unit_scale=True, unit_divisor=1000, total=total_size)
         else:
             prog_bar = None
+
+        if items is not None:
+            valid_items = [item.filename for item in zip_file.infolist()]
+            invalid_items = [item for item in items if item not in valid_items]
+            if len(invalid_items) > 0:
+                raise KeyError(f"The following items are not contained in the zipfile: {invalid_items}.")
 
         for item in zip_file.infolist():
             if items is not None and item.filename not in items:

--- a/src/pointtorch/io/_unzip.py
+++ b/src/pointtorch/io/_unzip.py
@@ -5,6 +5,7 @@ __all__ = ["unzip"]
 import pathlib
 from shutil import copyfileobj
 from typing import IO, Optional, Union
+import zipfile_deflate64  # pylint: disable: unused-import # needed to patch zipfile
 import zipfile
 
 from tqdm import tqdm

--- a/test/io/test_unzip.py
+++ b/test/io/test_unzip.py
@@ -71,13 +71,21 @@ class TestUnzip:
     ):
         cache_dir = pathlib.Path(cache_dir)
 
-        unzip(zip_file_path, cache_dir, items="test/test1.txt")
+        unzip(zip_file_path, cache_dir, items=["test/test1.txt"])
 
         file_path_0 = cache_dir / "test0.txt"
         file_path_1 = cache_dir / "test/test1.txt"
 
         assert not file_path_0.exists()
         assert file_path_1.exists()
+
+    def test_invalid_items(
+        self,
+        zip_file_path: Union[str, pathlib.Path],
+        cache_dir: str,
+    ):
+        with pytest.raises(KeyError):
+            unzip(zip_file_path, cache_dir, items=["non-existing-item"])
 
     def test_file_not_existing(self, cache_dir: str):
         with pytest.raises(FileNotFoundError):

--- a/test/io/test_unzip.py
+++ b/test/io/test_unzip.py
@@ -64,6 +64,21 @@ class TestUnzip:
             file_content = file.read()
             assert "Test1" == file_content
 
+    def test_selected_items(
+        self,
+        zip_file_path: Union[str, pathlib.Path],
+        cache_dir: str,
+    ):
+        cache_dir = pathlib.Path(cache_dir)
+
+        unzip(zip_file_path, cache_dir, items="test/test1.txt")
+
+        file_path_0 = cache_dir / "test0.txt"
+        file_path_1 = cache_dir / "test/test1.txt"
+
+        assert not file_path_0.exists()
+        assert file_path_1.exists()
+
     def test_file_not_existing(self, cache_dir: str):
         with pytest.raises(FileNotFoundError):
             unzip(os.path.join(cache_dir, "test.zip"), cache_dir)


### PR DESCRIPTION
This pull request refactors the `pointtorch.io.unzip()` method, making the following changes:
- Support for zip archives with deflate64 compression
- Support for partial unzipping of an archive (newly added keyword argument `items`)