### PR TITLE
fix: IoU-based instance matching

### DIFF
--- a/src/pointtorch/metrics/instance_segmentation/_match_instances.py
+++ b/src/pointtorch/metrics/instance_segmentation/_match_instances.py
@@ -320,6 +320,7 @@ def match_instances_iou(  # pylint: disable=too-many-statements, too-many-locals
         | :math:`P` = number of predicted instances
         | :math:`T` = number of target instances
     """
+    print("invalid_instance_id", invalid_instance_id)
 
     if min_iou_treshold is None:
         min_iou_treshold = -1
@@ -360,10 +361,18 @@ def match_instances_iou(  # pylint: disable=too-many-statements, too-many-locals
 
     target_ids_to_match, target_batch_indices = torch.unique_consecutive(paired_target_ids, return_inverse=True)
 
-    tp, best_predicted_ids = scatter_max(pair_counts, target_batch_indices, dim=0)
+    pair_target_sizes = target_sizes[paired_target_ids]
+    pair_predicted_sizes = predicted_sizes[paired_predicted_ids]
+    pair_ious = pair_counts.to(torch.float) / (
+        pair_target_sizes.to(torch.float) + pair_predicted_sizes.to(torch.float) - pair_counts.to(torch.float)
+    )
+
+    iou, best_predicted_ids = scatter_max(pair_ious, target_batch_indices, dim=0)
     predicted_ids_to_match = paired_predicted_ids[best_predicted_ids]
+    tp = pair_counts[best_predicted_ids]
 
     has_overlap = tp > 0
+    iou = iou[has_overlap]
     tp = tp[has_overlap]
     target_ids_to_match = target_ids_to_match[has_overlap]
     predicted_ids_to_match = predicted_ids_to_match[has_overlap]
@@ -373,8 +382,6 @@ def match_instances_iou(  # pylint: disable=too-many-statements, too-many-locals
 
     fp = predicted_sizes - tp
     fn = target_sizes - tp
-
-    iou = tp.to(torch.float) / (tp.to(torch.float) + fp + fn)
 
     if accept_equal_iou:
         matching_mask = iou >= min_iou_treshold

--- a/test/metrics/instance_segmentation/test_match_instances.py
+++ b/test/metrics/instance_segmentation/test_match_instances.py
@@ -239,10 +239,14 @@ class TestMetrics:
     ):
         start_instance_id = invalid_instance_id + 1
 
-        target = torch.tensor([0, -1, 2, 2, 3, -1, -1, 1, 1, 1, 1, -1, -1, -1, -1, -1], device=device) + start_instance_id
+        target = (
+            torch.tensor([0, -1, 2, 2, 3, -1, -1, 1, 1, 1, 1, -1, -1, -1, -1, -1], device=device) + start_instance_id
+        )
         unique_target_ids = torch.unique(target)
         unique_target_ids = unique_target_ids[unique_target_ids != invalid_instance_id]
-        prediction = torch.tensor([0, 0, 0, 0, 0, -1, -1, 1, 1, 2, -1, 1, 1, 1, 1, 1], device=device) + start_instance_id
+        prediction = (
+            torch.tensor([0, 0, 0, 0, 0, -1, -1, 1, 1, 2, -1, 1, 1, 1, 1, 1], device=device) + start_instance_id
+        )
         unique_prediction_ids = torch.unique(prediction)
         unique_prediction_ids = unique_prediction_ids[unique_prediction_ids != invalid_instance_id]
 

--- a/test/metrics/instance_segmentation/test_match_instances.py
+++ b/test/metrics/instance_segmentation/test_match_instances.py
@@ -239,19 +239,19 @@ class TestMetrics:
     ):
         start_instance_id = invalid_instance_id + 1
 
-        target = torch.tensor([0, -1, 2, 2, 3, -1, -1, 1, 1, 1], device=device) + start_instance_id
+        target = torch.tensor([0, -1, 2, 2, 3, -1, -1, 1, 1, 1, 1, -1, -1, -1, -1, -1], device=device) + start_instance_id
         unique_target_ids = torch.unique(target)
         unique_target_ids = unique_target_ids[unique_target_ids != invalid_instance_id]
-        prediction = torch.tensor([0, 0, 0, 0, 0, -1, -1, 2, 2, 1], device=device) + start_instance_id
+        prediction = torch.tensor([0, 0, 0, 0, 0, -1, -1, 1, 1, 2, -1, 1, 1, 1, 1, 1], device=device) + start_instance_id
         unique_prediction_ids = torch.unique(prediction)
         unique_prediction_ids = unique_prediction_ids[unique_prediction_ids != invalid_instance_id]
 
         expected_matched_target_ids = np.array([2, -1, 1], dtype=np.int64) + start_instance_id
         expected_matched_predicted_ids = np.array([0, 2, 0, 0], dtype=np.int64) + start_instance_id
         expected_metrics = {
-            "tp": np.array([1, 2, 2, 1], dtype=np.int64),
+            "tp": np.array([1, 1, 2, 1], dtype=np.int64),
             "fp": np.array([4, 0, 3, 4], dtype=np.int64),
-            "fn": np.array([0, 1, 0, 0], dtype=np.int64),
+            "fn": np.array([0, 3, 0, 0], dtype=np.int64),
         }
 
         matched_target_ids, matched_predicted_ids, metrics = match_instances_iou(


### PR DESCRIPTION
Fixes a bug in the instance `pointtorch.metrics.instance_segmentation.match_instances_iou`: Previously, the matches were determined based on the overlap (i.e., number of true positive points) between predicted and target instances. This could result in incorrect matching in certain edge cases, where the predicted instance with the highest overlap with a target instance was not the instance with the highest IoU with the target instance. To address this issue, matches are now determined based on IoU.