### PR TITLE
fix: correctly read scaled extra dimensions in las/laz files

### DIFF
--- a/src/pointtorch/io/_las_reader.py
+++ b/src/pointtorch/io/_las_reader.py
@@ -95,7 +95,8 @@ class LasReader(BasePointCloudReader):
         for column_name in las_header.point_format.extra_dimension_names:
             if column_name.lower() in ["x", "y", "z"] or columns is not None and column_name not in columns:
                 continue
-            point_cloud_df[column_name] = las_data[column_name]
+            column_values = np.array(las_data[column_name])
+            point_cloud_df[column_name] = column_values
 
         return point_cloud_df
 

--- a/test/io/test_las_reader.py
+++ b/test/io/test_las_reader.py
@@ -5,6 +5,7 @@ import pathlib
 import shutil
 from typing import Optional, Union
 
+import laspy
 import numpy as np
 import pandas as pd
 import pytest
@@ -66,6 +67,33 @@ class TestLasReader:
         read_point_cloud_data = las_reader.read(file_path, columns=columns, num_rows=num_rows)
 
         assert (point_cloud_df.to_numpy() == read_point_cloud_data.data.to_numpy()).all()
+
+    @pytest.mark.parametrize("file_format", ["las", "laz"])
+    @pytest.mark.parametrize("use_pathlib", [True, False])
+    def test_read_scaled_extra_dimension(
+        self, las_reader: LasReader, cache_dir: str, file_format: str, use_pathlib: bool
+    ):
+        expected_values = np.array([10.0, 10.123, 10.5, 11.0, 12.0])
+
+        las_data = laspy.create(point_format=6)
+        coords = np.arange(len(expected_values), dtype=float)
+        las_data.x = coords
+        las_data.y = coords
+        las_data.z = coords
+        las_data.add_extra_dim(
+            laspy.ExtraBytesParams(name="scaled_dim", type=np.int32, scales=np.array([0.001]), offsets=np.array([10.0]))
+        )
+        las_data.scaled_dim = expected_values
+
+        file_path: Union[str, pathlib.Path] = os.path.join(cache_dir, f"test_point_cloud.{file_format}")
+        if use_pathlib:
+            file_path = pathlib.Path(file_path)
+
+        las_data.write(file_path)
+
+        read_point_cloud_data = las_reader.read(file_path)
+
+        assert np.allclose(expected_values, read_point_cloud_data.data["scaled_dim"].to_numpy())
 
     def test_read_unsupported_format(self, las_reader: LasReader, cache_dir: str):
         file_path = pathlib.Path(cache_dir) / "test_file.invalid"


### PR DESCRIPTION
Extra dimensions with a scale/offset were read incorrectly. The column ended up with `object` dtype containing the same `ScaledArrayView` in every row instead of the actual per-point values.

Now wrap extra-dimension values in `np.array(...)` before assigning them to the DataFrame, which applies the scale and offset, just like how the standard dimensions are already read.

Added `test_read_scaled_extra_dimension`. It builds the file with a scaled extra dimension directly via laspy
